### PR TITLE
Update base.html

### DIFF
--- a/voting/templates/voting/base.html
+++ b/voting/templates/voting/base.html
@@ -111,7 +111,7 @@
     </script> -->
 
     <script>
-        toastr.{{ message.tags }}('{{ message }}', '{{ message.tags|title }}');
+        toastr["{{ message.tags }}"]('{{ message }}', '{{ message.tags|title }}');
     </script>
     {% endfor %}
     {% endif %}


### PR DESCRIPTION
Corrected syntax. Since message.tags is dynamically passed from Django, bracket notation will be used (toastr["{{ message.tags }}"]) instead of dot notation.